### PR TITLE
Bug Fixed: No. of questions that can be accepted

### DIFF
--- a/AdminGui.py
+++ b/AdminGui.py
@@ -37,6 +37,7 @@ class AdminGui(Gui):
 	mutePlayers = pyqtSignal(list)
 	unmutePlayers = pyqtSignal(list)
 
+
 	def __init__(self, parent=None):
 		super(AdminGui, self).__init__(parent)
 		self.game = None # if something goes wrong with the game server, we'll have a nice cleanup
@@ -58,6 +59,8 @@ class AdminGui(Gui):
 		# prepare to tell the time elapsed since the game started
 		self.time = QTime(0, 0, 0)
 		self.timer = QTimer(self)
+                # maintains the picked questions order
+		self.question_queue = []
 		self.timer.timeout.connect(self.displayTime)
 
 	def loadRules(self):
@@ -183,10 +186,16 @@ class AdminGui(Gui):
 		self.time = self.time.addSecs(1)
 		self.getLabel().setText(self.time.toString())
 
-	#################################
-	def acceptQuestion(self, i):
-		message =  'Question:\n' + self.getQuestion()['statement']
-		ans = QMessageBox.warning(self, '', message, QMessageBox.Ok, QMessageBox.Cancel)
+	def acceptQuestion(self, i,name):
+		first_message =  'Question selected by ' + name + ':\n' + self.getQuestion()['statement']
+                other_message = 'There already is another question selected, please accept that one!\nQuestion picked by: ' + name
+        	self.question_queue.append(1)
+        	if len(self.question_queue) == 1:
+		    ans = QMessageBox.information(self, '', first_message, QMessageBox.Ok, QMessageBox.Cancel)
+        	else:
+		    ans = QMessageBox.warning(self, '', other_message, QMessageBox.Cancel)
+                self.question_queue.pop()
+                
 		print('intrebarea a fost acceptata prin warning.. debugging what do you want?')
 		if ans == QMessageBox.Ok:
 			self.getGrid().buttonClicked.emit(i)

--- a/AdminGui.py
+++ b/AdminGui.py
@@ -37,7 +37,6 @@ class AdminGui(Gui):
 	mutePlayers = pyqtSignal(list)
 	unmutePlayers = pyqtSignal(list)
 
-
 	def __init__(self, parent=None):
 		super(AdminGui, self).__init__(parent)
 		self.game = None # if something goes wrong with the game server, we'll have a nice cleanup
@@ -59,7 +58,7 @@ class AdminGui(Gui):
 		# prepare to tell the time elapsed since the game started
 		self.time = QTime(0, 0, 0)
 		self.timer = QTimer(self)
-                # maintains the picked questions order
+		# maintains the picked questions order
 		self.question_queue = []
 		self.timer.timeout.connect(self.displayTime)
 
@@ -172,7 +171,8 @@ class AdminGui(Gui):
 		@type name: str
 		"""
 
-		ans = QMessageBox.information(self, '', 'Player ' + name + ' is answering.\nIs the answer correct?', QMessageBox.Yes | QMessageBox.No)
+		ans = QMessageBox.information(self, '', 'Player ' + name 
+			+ ' is answering.\nIs the answer correct?', QMessageBox.Yes | QMessageBox.No)
 		if ans == QMessageBox.Yes:
 			add = True
 		else:
@@ -187,16 +187,17 @@ class AdminGui(Gui):
 		self.getLabel().setText(self.time.toString())
 
 	def acceptQuestion(self, i,name):
-		first_message =  'Question selected by ' + name + ':\n' + self.getQuestion()['statement']
-                other_message = 'There already is another question selected, please accept that one!\nQuestion picked by: ' + name
-        	self.question_queue.append(1)
-        	if len(self.question_queue) == 1:
-		    ans = QMessageBox.information(self, '', first_message, QMessageBox.Ok, QMessageBox.Cancel)
-        	else:
-		    ans = QMessageBox.warning(self, '', other_message, QMessageBox.Cancel)
-                self.question_queue.pop()
-                
-		print('intrebarea a fost acceptata prin warning.. debugging what do you want?')
+		first_message =  'Question selected by ' + name + ':\n' 
+				+ self.getQuestion()['statement']
+		other_message = 'There already is another question selected,'
+			+' please accept that one!\nQuestion picked by: ' + name
+		self.question_queue.append(1)
+		if len(self.question_queue) == 1:
+			ans = QMessageBox.information(self, '', first_message, 
+				QMessageBox.Ok, QMessageBox.Cancel)
+		else:
+			ans = QMessageBox.warning(self, '', other_message, QMessageBox.Cancel)
+		self.question_queue.pop()
 		if ans == QMessageBox.Ok:
 			self.getGrid().buttonClicked.emit(i)
 

--- a/AdminGui.py
+++ b/AdminGui.py
@@ -187,10 +187,10 @@ class AdminGui(Gui):
 		self.getLabel().setText(self.time.toString())
 
 	def acceptQuestion(self, i,name):
-		first_message =  'Question selected by ' + name + ':\n' 
-				+ self.getQuestion()['statement']
-		other_message = 'There already is another question selected,'
-			+' please accept that one!\nQuestion picked by: ' + name
+		first_message =  ('Question selected by ' + name + ':\n' 
+				+ self.getQuestion()['statement'])
+		other_message = ('There already is another question selected,'
+			+' please accept that one!\nQuestion picked by: ' + name)
 		self.question_queue.append(1)
 		if len(self.question_queue) == 1:
 			ans = QMessageBox.information(self, '', first_message, 

--- a/Game.py
+++ b/Game.py
@@ -201,10 +201,10 @@ class Game(Pyro.core.ObjBase):
 		return deepcopy(self.server.scores)
 
 	###################################
-	def acceptQuestion(self, i):
+	def acceptQuestion(self, i, name):
 		"""
 		This function gets called when the player selects a Question
 		The admin is required to accept the Question (or not) for the actual question to be displayed to all players.
 		"""
 		print('question is', i)
-		self.server.accQuestion.emit(i)
+		self.server.accQuestion.emit(i, name)

--- a/GameServer.py
+++ b/GameServer.py
@@ -39,8 +39,8 @@ class GameServer(Server):
 	playerStatusChanged = pyqtSignal(tuple)
 
 	playerBuzzed = pyqtSignal(str)
-	questionSelected = pyqtSignal(int) ##########
-	accQuestion = pyqtSignal(int,str) ###########
+	questionSelected = pyqtSignal(int)
+	accQuestion = pyqtSignal(int,str)
 
 	labelTextSet = pyqtSignal(str)
 	allGamesStarted = pyqtSignal()

--- a/GameServer.py
+++ b/GameServer.py
@@ -39,8 +39,8 @@ class GameServer(Server):
 	playerStatusChanged = pyqtSignal(tuple)
 
 	playerBuzzed = pyqtSignal(str)
-	questionSelected = pyqtSignal(int)
-	accQuestion = pyqtSignal(int) ###########
+	questionSelected = pyqtSignal(int) ##########
+	accQuestion = pyqtSignal(int,str) ###########
 
 	labelTextSet = pyqtSignal(str)
 	allGamesStarted = pyqtSignal()
@@ -174,7 +174,7 @@ class GameServer(Server):
 		category = self.round['categories'][c]
 		self.question = deepcopy(category['questions'][q])
 		self.question['category'] = category['title']
-		print('dsadsadsaadasdas')
+		print('Question is chosen')
 
 	def selectQuestion(self, i):
 		"""

--- a/PlayerServer.py
+++ b/PlayerServer.py
@@ -77,8 +77,8 @@ class PlayerServer(Server):
 	def buzz(self):
 		self.game.buzz(self.name)
 
-	###################
+	# Passes the question and the player's name who picked it
 	def pickQuestion(self, i):
 		print('question picked is', i)
-		self.game.acceptQuestion(i)
+		self.game.acceptQuestion(i, self.name)
 


### PR DESCRIPTION
As a response to the bug submitted by mihaimaruseac, i have limited the numbers of questions that can be accepted by the admin. If another question is chosen by any other player, it can only be rejected in order not to accidentally skip one of them. I also added in the message box the name of the player who picked the question, so that the admin can accept the right question.

To get the number of questions picked, i have added each one in a stack, and as soon as it is processed(accepted or refused) it is poped it out. When a new question is picked, the length of the stack is evaluated and a proper message is displayed.
